### PR TITLE
Handle in-ns statements.

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -38,8 +38,14 @@
                        (if ignore-unreadable?
                          ::done
                          (throw e))))]
-       (if (and (list? form) (= 'ns (first form)))
+       (cond
+         (and (list? form) (= 'ns (first form)))
          form
+
+         (and (list? form) (= 'in-ns (first form)))
+         nil
+
+         :else
          (when-not (= ::done form)
            (recur rdr ignore-unreadable?))))))
 


### PR DESCRIPTION
`lein test` breaks on files that start with `in-ns`, and which refer to keyword
abbreviations (`::foo/bar`) and namespaced map abbreviations (`#::foo{:bar :baz}`).

* src/bultitude/core.clj (read-ns-form): ignore files that begin with
  a form `(in-ns ...)`.